### PR TITLE
Versions update.

### DIFF
--- a/code/pom.xml
+++ b/code/pom.xml
@@ -86,10 +86,14 @@
         <spotbugs.exclude>${project.basedir}/exclude.xml</spotbugs.exclude>
         <spotbugs.skip>false</spotbugs.skip>
         <spotbugs.threshold>Low</spotbugs.threshold>
-        <spotbugs.version>4.0.0</spotbugs.version>
+        <spotbugs.version>4.0.4</spotbugs.version>
+
+        <xsom.version>3.0.0-M4</xsom.version>
+        <streambuffer.version>2.0.0</streambuffer.version>
+        <junit.version>4.13</junit.version>
+        <jakarta.activation-api.version>2.0.0</jakarta.activation-api.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit-version>4.12</junit-version>
         <legal.doc.source>${maven.multiModuleProjectDirectory}/..</legal.doc.source>
         <vendor.name>Eclipse Foundation</vendor.name>
     </properties>
@@ -106,18 +110,24 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>xsom</artifactId>
-                <version>2.3.3-b02</version>
+                <version>${xsom.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.stream.buffer</groupId>
                 <artifactId>streambuffer</artifactId>
-                <version>2.0.0-M2</version>
+                <version>${streambuffer.version}</version>
             </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit-version}</version>
-        </dependency>
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+            <!-- Used only in FastInfosetUtilities module -->
+            <dependency>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>${jakarta.activation-api.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -140,7 +150,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
@@ -171,7 +181,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>4.2.1</version>
+                    <version>5.1.1</version>
                     <configuration>
                         <instructions>
                             <_noextraheaders>true</_noextraheaders>

--- a/code/pom.xml
+++ b/code/pom.xml
@@ -91,7 +91,7 @@
         <xsom.version>3.0.0-M4</xsom.version>
         <streambuffer.version>2.0.0</streambuffer.version>
         <junit.version>4.13</junit.version>
-        <jakarta.activation-api.version>2.0.0</jakarta.activation-api.version>
+        <activation-api.version>2.0.0</activation-api.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <legal.doc.source>${maven.multiModuleProjectDirectory}/..</legal.doc.source>
@@ -126,7 +126,7 @@
             <dependency>
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>
-                <version>${jakarta.activation-api.version}</version>
+                <version>${activation-api.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/code/utilities/pom.xml
+++ b/code/utilities/pom.xml
@@ -50,7 +50,6 @@
         <dependency>
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>
-            <version>2.0.0-RC2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
[INFO] No plugins require a newer version of Maven than specified by the pom.
JDK 14 build works.
