### PR TITLE
Replace usage of deprecated XSOMParser constructor

### DIFF
--- a/fastinfoset/src/main/java/com/sun/xml/fastinfoset/Encoder.java
+++ b/fastinfoset/src/main/java/com/sun/xml/fastinfoset/Encoder.java
@@ -1033,10 +1033,8 @@ public abstract class Encoder extends DefaultHandler implements FastInfosetSeria
         if (entry._valueIndex > 0) {
             QualifiedName[] names = entry._value;
             for (int i = 0; i < entry._valueIndex; i++) {
-                if ((prefix.equals(names[i].prefix)
-                        || prefix.equals(names[i].prefix))
-                        && (namespaceURI.equals(names[i].namespaceName)
-                        || namespaceURI.equals(names[i].namespaceName))) {
+                if (prefix.equals(names[i].prefix)
+                        && namespaceURI.equals(names[i].namespaceName)) {
                     encodeNonZeroIntegerOnThirdBit(names[i].index);
                     return;
                 }
@@ -1119,10 +1117,8 @@ public abstract class Encoder extends DefaultHandler implements FastInfosetSeria
         if (entry._valueIndex > 0) {
             QualifiedName[] names = entry._value;
             for (int i = 0; i < entry._valueIndex; i++) {
-                if ((prefix.equals(names[i].prefix)
-                        || prefix.equals(names[i].prefix))
-                        && (namespaceURI.equals(names[i].namespaceName)
-                        || namespaceURI.equals(names[i].namespaceName))) {
+                if (prefix.equals(names[i].prefix)
+                        && namespaceURI.equals(names[i].namespaceName)) {
                     encodeNonZeroIntegerOnSecondBitFirstBitZero(names[i].index);
                     return;
                 }
@@ -1149,8 +1145,7 @@ public abstract class Encoder extends DefaultHandler implements FastInfosetSeria
         if (namespaceURI.length() > 0) {
             namespaceURIIndex = _v.namespaceName.get(namespaceURI);
             if (namespaceURIIndex == KeyIntMap.NOT_PRESENT) {
-                if (namespaceURI.equals(EncodingConstants.XMLNS_NAMESPACE_NAME)
-                        || namespaceURI.equals(EncodingConstants.XMLNS_NAMESPACE_NAME)) {
+                if (namespaceURI.equals(EncodingConstants.XMLNS_NAMESPACE_NAME)) {
                     return false;
                 } else {
                     throw new IOException(CommonResourceBundle.getInstance().getString("message.namespaceURINotIndexed", new Object[]{namespaceURI}));

--- a/roundtrip-tests/src/main/java/com/sun/xml/fastinfoset/roundtriptests/AllRoundTripTest.java
+++ b/roundtrip-tests/src/main/java/com/sun/xml/fastinfoset/roundtriptests/AllRoundTripTest.java
@@ -30,6 +30,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author Alexey Stashok
@@ -51,7 +52,7 @@ public class AllRoundTripTest {
         cleanupDiffs(testSrcFile);
         
         try {
-            PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(report)));
+            PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(report)), false, StandardCharsets.UTF_8);
             try {
                 writer.print(reporter.generateReport());
             } finally {

--- a/roundtrip-tests/src/main/java/com/sun/xml/fastinfoset/roundtriptests/RoundTripReport.java
+++ b/roundtrip-tests/src/main/java/com/sun/xml/fastinfoset/roundtriptests/RoundTripReport.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -137,7 +138,7 @@ public class RoundTripReport {
             String content = reportContent(filename, args);
             osr = new OutputStreamWriter(
                     new FileOutputStream(
-                    new File(filename)));
+                    new File(filename)), StandardCharsets.UTF_8);
             osr.write(content);
         } catch (Exception e) {
             e.printStackTrace();
@@ -204,7 +205,7 @@ public class RoundTripReport {
             
             // Convert our input stream to a
             // DataInputStream
-            in = new BufferedReader(new InputStreamReader(fstream));
+            in = new BufferedReader(new InputStreamReader(fstream, StandardCharsets.UTF_8));
             
             String s;
             while ((s = in.readLine()) != null) {

--- a/roundtrip-tests/src/main/java/com/sun/xml/fastinfoset/roundtriptests/SingleRountTripTest.java
+++ b/roundtrip-tests/src/main/java/com/sun/xml/fastinfoset/roundtriptests/SingleRountTripTest.java
@@ -24,6 +24,7 @@ import java.io.FileFilter;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 /**
@@ -83,7 +84,7 @@ public class SingleRountTripTest {
         
         RoundTripReport report = new RoundTripReport();
         new SingleRountTripTest((RoundTripRtt) Class.forName(args[0]).getConstructor().newInstance(), report).processFileOrFolder(new File(args[1]));
-        try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(args[2])))) {
+        try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(args[2])), false, StandardCharsets.UTF_8)) {
             writer.print(report.generateReport());
         }
     }

--- a/roundtrip-tests/src/main/java/com/sun/xml/fastinfoset/roundtriptests/rtt/RoundTripRtt.java
+++ b/roundtrip-tests/src/main/java/com/sun/xml/fastinfoset/roundtriptests/rtt/RoundTripRtt.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 /**
  *
@@ -87,7 +88,7 @@ public abstract class RoundTripRtt {
     }
 
     public boolean diffBinary(String fileName1, String fileName2, String diffFileName) throws IOException {
-        PrintWriter diffWriter = new PrintWriter(new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(diffFileName))));
+        PrintWriter diffWriter = new PrintWriter(new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(diffFileName))), false, StandardCharsets.UTF_8);
         InputStream file1InputStream = null;
         InputStream file2InputStream = null;
         
@@ -163,9 +164,9 @@ public abstract class RoundTripRtt {
         PrintWriter diffWriter = null;
         
         try {
-            file1Reader = new BufferedReader(new InputStreamReader(new FileInputStream(fileName1)));
-            file2Reader = new BufferedReader(new InputStreamReader(new FileInputStream(fileName2)));
-            diffWriter = new PrintWriter(new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(diffFileName))));
+            file1Reader = new BufferedReader(new InputStreamReader(new FileInputStream(fileName1), StandardCharsets.UTF_8));
+            file2Reader = new BufferedReader(new InputStreamReader(new FileInputStream(fileName2), StandardCharsets.UTF_8));
+            diffWriter = new PrintWriter(new OutputStreamWriter(new BufferedOutputStream(new FileOutputStream(diffFileName))), false, StandardCharsets.UTF_8);
             
             boolean passed = true;
             String line1 = null;

--- a/utilities/src/main/java/com/sun/xml/analysis/frequency/SchemaProcessor.java
+++ b/utilities/src/main/java/com/sun/xml/analysis/frequency/SchemaProcessor.java
@@ -42,6 +42,7 @@ import com.sun.xml.xsom.XSUnionSimpleType;
 import com.sun.xml.xsom.XSWildcard;
 import com.sun.xml.xsom.XSXPath;
 import com.sun.xml.xsom.parser.XSOMParser;
+import com.sun.xml.xsom.parser.JAXPParser;
 import com.sun.xml.xsom.visitor.XSSimpleTypeVisitor;
 import com.sun.xml.xsom.visitor.XSVisitor;
 import java.io.File;
@@ -56,6 +57,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
+import javax.xml.parsers.SAXParserFactory;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -415,7 +417,10 @@ public class SchemaProcessor {
      * information items.
      */
     public void process() throws Exception {
-        XSOMParser parser = new XSOMParser();
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        XSOMParser parser = new XSOMParser(factory);
         parser.setErrorHandler(new ErrorHandlerImpl());
         
         for (URL u : _schema) {

--- a/utilities/src/main/java/com/sun/xml/analysis/types/SchemaProcessor.java
+++ b/utilities/src/main/java/com/sun/xml/analysis/types/SchemaProcessor.java
@@ -56,7 +56,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
+import javax.xml.parsers.SAXParserFactory;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -334,7 +336,10 @@ public class SchemaProcessor {
     public void process(Set<XSDataType> filter) throws Exception {
         _filter = filter;
         
-        XSOMParser parser = new XSOMParser();
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        XSOMParser parser = new XSOMParser(factory);
         parser.setErrorHandler(new ErrorHandlerImpl());
         
         for (URL u : _schema) {


### PR DESCRIPTION
The deprecated no-parameter constructor of `XSOMParser` has been removed in `jaxb-ri` version 4.0.1.